### PR TITLE
feat(version): adds posibility to pass build number

### DIFF
--- a/lib/fastlane/plugin/cordova/version.rb
+++ b/lib/fastlane/plugin/cordova/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Cordova
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Also fixed 2 issue:
1. Proper shell args escaping (my password contains ! and " simbols)
2. Pass only platform specific args during cordova build (it means that for iOS build android args won't be parsed and the same for Android build)