### PR TITLE
Don't require build_number to be numeric

### DIFF
--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -192,9 +192,8 @@ module Fastlane
             key: :build_number,
             env_name: "CORDOVA_BUILD_NUMBER",
             description: "Build Number for iOS and Android Keystore alias",
-            default_value: 0,
+            optional: true,
             is_string: false,
-            type: Numeric
           )
         ]
       end


### PR DESCRIPTION
Fixes #10

This is a potential fix for the issue described in #10. This completely removes the restriction that `build_number` be a numeric value, which allows fastlane-plugin-cordova to better support the full range of allowed values for CFBundleVersion on iOS. If that's not desirable, there might be another way to just allow numeric values in environment variables.

I haven't added any test cases because it doesn't look like this project has any, but I manually tested and verified that #10 is resolved and that this isn't a breaking change for existing projects, i.e.:

```ruby
cordova(
    platform: "android",
    build_number: 7,
)
```

```ruby
cordova(
    platform: "android",
    build_number: "7",
)
```

```
CORDOVA_BUILD_NUMBER=7 bundle exec fastlane cordova ...
```

all work as intended, you can still pass `build_number` in as either a number or a string.