### PR TITLE
Fix build_number on iOS

### DIFF
--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -75,6 +75,10 @@ module Fastlane
         android_args = self.get_android_args(params) if params[:platform].to_s == 'android'
         ios_args = self.get_ios_args(params) if params[:platform].to_s == 'ios'
 
+        if params[:cordova_prepare]
+          sh "cordova prepare #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
+        end
+
         if params[:platform].to_s == 'ios' && !params[:build_number].to_s.empty?
           cf_bundle_version = params[:build_number].to_s
           Actions::UpdateInfoPlistAction.run(
@@ -86,7 +90,7 @@ module Fastlane
           )
         end
 
-        sh "cordova build #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
+        sh "cordova compile #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
       end
 
       def self.set_build_paths(is_release)
@@ -211,6 +215,13 @@ module Fastlane
             env_name: "CORDOVA_BROWSERIFY",
             description: "Specifies whether to browserify build or not",
             default_value: false,
+            is_string: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :cordova_prepare,
+            env_name: "CORDOVA_PREPARE",
+            description: "Specifies whether to run `cordova prepare` before building",
+            default_value: true,
             is_string: false
           )
         ]

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -18,7 +18,6 @@ module Fastlane
         type: 'packageType',
         team_id: 'developmentTeam',
         provisioning_profile: 'provisioningProfile',
-        build_number: 'CFBundleVersion'
       }
 
       def self.get_platform_args(params, args_map)
@@ -74,6 +73,17 @@ module Fastlane
         device = params[:device] ? ' --device' : ''
         android_args = self.get_android_args(params) if params[:platform].to_s == 'android'
         ios_args = self.get_ios_args(params) if params[:platform].to_s == 'ios'
+
+        if params[:platform].to_s == 'ios' && !params[:build_number].to_s.empty?
+          cf_bundle_version = params[:build_number].to_s
+          Actions::UpdateInfoPlistAction.run(
+            xcodeproj: "./platforms/ios/#{self.get_app_name}.xcodeproj",
+            plist_path: "#{self.get_app_name}/#{self.get_app_name}-Info.plist",
+            block: lambda { |plist|
+              plist['CFBundleVersion'] = cf_bundle_version
+            }
+          )
+        end
 
         sh "cordova build #{params[:platform]} --#{prod}#{device} #{ios_args} -- #{android_args}"
       end


### PR DESCRIPTION
In the discussion for #9, the suggestions was to just modify the `Info.plist` to update the `CFBundleVersion` parameter. Turns it the solution is a bit more complicated than that, because `cordova build` always overwrites `CFBundleVersion`. This is because `cordova prepare`, re-generates the Xcode project, and `cordova build` calls `cordova prepare` under the hood.

To fix this issue, I had to split the calls to `cordova prepare` and `cordova compile` to be made separately, that way we can modify the value of `CFBundleVersion` after the Xcode project has been generated but before the `.ipa` is built.

In doing so, I've also added a flag `cordova_prepare` that allows user to skip the call to `cordova prepare` if they choose to do so. I happen to have a case where I call `cordova prepare` separately, so it's helpful for me to be able have fastlane-plugin-cordova` not call it again.

Fixes #9