### PR TITLE
Add an option to set minSdkVersion for android compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If using **Crosswalk**, replace `supply(apk: ENV['CORDOVA_ANDROID_RELEASE_BUILD_
 ```
 supply(
   apk_paths: [
-   'platforms/android/build/outputs/apk/android-armv7-release.apk', 
+   'platforms/android/build/outputs/apk/android-armv7-release.apk',
    'platforms/android/build/outputs/apk/android-x86-release.apk'
   ],
 )
@@ -82,6 +82,7 @@ Which will produce:
 | **keystore_password**    | Android Keystore password                               | CORDOVA_ANDROID_KEYSTORE_PASSWORD |           |
 | **key_password**         | Android Key password (default is keystore password)     | CORDOVA_ANDROID_KEY_PASSWORD      |           |
 | **keystore_alias**       | Android Keystore alias                                  | CORDOVA_ANDROID_KEYSTORE_ALIAS    |           |
+| **min_sdk_version**      | Overrides the value of minSdkVersion                    | CORDOVA_ANDROID_MIN_SDK_VERSION   |           |
 | **build_number**         | Build Number for iOS and Android                        | CORDOVA_BUILD_NUMBER              |           |
 | **browserify**           | Specifies whether to browserify build or not            | CORDOVA_BROWSERIFY                |  *false*  |
 | **cordova_prepare**      | Specifies whether to run `cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -11,7 +11,8 @@ module Fastlane
         keystore_password: 'storePassword',
         key_password: 'password',
         keystore_alias: 'alias',
-        build_number: 'versionCode'
+        build_number: 'versionCode',
+        min_sdk_version: 'cdvMinSdkVersion'
       }
 
       IOS_ARGS_MAP = {
@@ -222,6 +223,13 @@ module Fastlane
             env_name: "CORDOVA_PREPARE",
             description: "Specifies whether to run `cordova prepare` before building",
             default_value: true,
+            is_string: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :min_sdk_version,
+            env_name: "CORDOVA_ANDROID_MIN_SDK_VERSION",
+            description: "Overrides the value of minSdkVersion set in AndroidManifest.xml",
+            default_value: false,
             is_string: false
           )
         ]

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -12,7 +12,7 @@ module Fastlane
         key_password: 'password',
         keystore_alias: 'alias',
         build_number: 'versionCode',
-        min_sdk_version: 'cdvMinSdkVersion'
+        min_sdk_version: 'gradleArg=-PcdvMinSdkVersion'
       }
 
       IOS_ARGS_MAP = {

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -229,7 +229,7 @@ module Fastlane
             key: :min_sdk_version,
             env_name: "CORDOVA_ANDROID_MIN_SDK_VERSION",
             description: "Overrides the value of minSdkVersion set in AndroidManifest.xml",
-            default_value: false,
+            default_value: '',
             is_string: false
           )
         ]


### PR DESCRIPTION
Hopefully this fixes https://github.com/bamlab/fastlane-plugin-cordova/issues/18.
I'll try to test this on my end, but it would be nice if someone could take a look into it.

Thanks