### PR TITLE
Option to add `--nofetch` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Which will produce:
 | **build_number**         | Build Number for iOS and Android                        | CORDOVA_BUILD_NUMBER              |           |
 | **browserify**           | Specifies whether to browserify build or not            | CORDOVA_BROWSERIFY                |  *false*  |
 | **cordova_prepare**      | Specifies whether to run `cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |
+| **cordova_no_fetch**      | Specifies whether to run `cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
 
 ## Run tests for this plugin
 

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -12,7 +12,8 @@ module Fastlane
         key_password: 'password',
         keystore_alias: 'alias',
         build_number: 'versionCode',
-        min_sdk_version: 'gradleArg=-PcdvMinSdkVersion'
+        min_sdk_version: 'gradleArg=-PcdvMinSdkVersion',
+        cordova_no_fetch: 'cordovaNoFetch'
       }
 
       IOS_ARGS_MAP = {
@@ -58,9 +59,14 @@ module Fastlane
         return self.get_platform_args(params, IOS_ARGS_MAP)
       end
 
-      def self.check_platform(platform)
+      def self.check_platform(params)
+        platform = params[:platform]
         if platform && !File.directory?("./platforms/#{platform}")
-          sh "cordova platform add #{platform}"
+          if params[:cordova_no_fetch]
+            sh "cordova platform add #{platform} --nofetch"
+          else
+            sh "cordova platform add #{platform}"
+          end
         end
       end
 
@@ -103,7 +109,7 @@ module Fastlane
       end
 
       def self.run(params)
-        self.check_platform(params[:platform])
+        self.check_platform(params)
         self.build(params)
         self.set_build_paths(params[:release])
       end
@@ -230,6 +236,13 @@ module Fastlane
             env_name: "CORDOVA_ANDROID_MIN_SDK_VERSION",
             description: "Overrides the value of minSdkVersion set in AndroidManifest.xml",
             default_value: '',
+            is_string: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :cordova_no_fetch,
+            env_name: "CORDOVA_NO_FETCH",
+            description: "Call `cordova platform add` with `--nofetch` parameter",
+            default_value: false,
             is_string: false
           )
         ]

--- a/lib/fastlane/plugin/cordova/version.rb
+++ b/lib/fastlane/plugin/cordova/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Cordova
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
In Cordova 7.0.0 there is the option to not fetch plugins/modules from npm directly with the `--nofetch` command. To use this functionality within the fastlane-plugin-cordova, I have added a parameter that specifies whether to run the `cordova platform add` command with `--nofetch` or not.