### PR TITLE
Update CORDOVA_ANDROID_RELEASE_BUILD_PATH to correct default output

### DIFF
--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -104,7 +104,7 @@ module Fastlane
         app_name = self.get_app_name()
         build_type = is_release ? 'release' : 'debug'
 
-        ENV['CORDOVA_ANDROID_RELEASE_BUILD_PATH'] = "./platforms/android/build/outputs/apk/app-#{build_type}.apk"
+        ENV['CORDOVA_ANDROID_RELEASE_BUILD_PATH'] = "./platforms/android/app/build/outputs/apk/release/app-#{build_type}.apk"
         ENV['CORDOVA_IOS_RELEASE_BUILD_PATH'] = "./platforms/ios/build/device/#{app_name}.ipa"
       end
 

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -104,7 +104,7 @@ module Fastlane
         app_name = self.get_app_name()
         build_type = is_release ? 'release' : 'debug'
 
-        ENV['CORDOVA_ANDROID_RELEASE_BUILD_PATH'] = "./platforms/android/build/outputs/apk/android-#{build_type}.apk"
+        ENV['CORDOVA_ANDROID_RELEASE_BUILD_PATH'] = "./platforms/android/build/outputs/apk/app-#{build_type}.apk"
         ENV['CORDOVA_IOS_RELEASE_BUILD_PATH'] = "./platforms/ios/build/device/#{app_name}.ipa"
       end
 


### PR DESCRIPTION
Updated "CORDOVA_ANDROID_RELEASE_BUILD_PATH" variable to be updated from "android" to the new "app" standard with Cordova & Android Studio.

More explanation of why it needs to be updated is here:
![env-update](https://user-images.githubusercontent.com/3174134/42970346-b427dc72-8b6e-11e8-85da-c015aceeb253.png)
