### PR TITLE
feat: add support for cordova buildConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Which will produce:
 | **browserify**           | Specifies whether to browserify build or not            | CORDOVA_BROWSERIFY                |  *false*  |
 | **cordova_prepare**      | Specifies whether to run `cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |
 | **cordova_no_fetch**      | Specifies whether to run `cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
+| **cordova_build_config_file**      | Call `cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path  | CORDOVA_BUILD_CONFIG_FILE               |     |
 
 ## Run tests for this plugin
 

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -89,6 +89,11 @@ module Fastlane
         args = [params[:release] ? '--release' : '--debug']
         args << '--device' if params[:device]
         args << '--browserify' if params[:browserify]
+
+        if !params[:cordova_build_config_file].to_s.empty?
+          args << "--buildConfig=#{Shellwords.escape(params[:cordova_build_config_file])}"
+        end
+
         android_args = self.get_android_args(params) if params[:platform].to_s == 'android'
         ios_args = self.get_ios_args(params) if params[:platform].to_s == 'ios'
 
@@ -262,6 +267,14 @@ module Fastlane
             is_string: false,
             optional: true,
             default_value: []
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :cordova_build_config_file,
+            env_name: "CORDOVA_BUILD_CONFIG_FILE",
+            description: "Call `cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path",
+            is_string: true,
+            optional: true,
+            defaultValue: ''
           )
         ]
       end


### PR DESCRIPTION
Add support for cordova buildConfig CLI argument. It will allow placing the `build.json` file anywhere.

It can be useful in some repos setup with non-standard directory structure.

cc: @Almouro 

@janpio your review would be appreciated :) It seems to work but I still lack knowledge on escape so I can't be sure it will always be ok on all possible paths such as `../../someConfig.json`