### PR TITLE
Fix for default value parameter name

### DIFF
--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -274,7 +274,7 @@ module Fastlane
             description: "Call `cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path",
             is_string: true,
             optional: true,
-            defaultValue: ''
+            default_value: ''
           )
         ]
       end


### PR DESCRIPTION
Can you please merge this as soon as possible and release a new version?  This is breaking an automated production build.