### PR TITLE
Add compatibility with yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Which will produce:
 | **cordova_prepare**      | Specifies whether to run `cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |
 | **cordova_no_fetch**      | Specifies whether to run `cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
 | **cordova_build_config_file**      | Call `cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path  | CORDOVA_BUILD_CONFIG_FILE               |     |
+| **node_package_manager** | Specifies which package manager to use to run cordova commands currently either `npm` or `yarn` | NODE_PACKAGE_MANAGER | *npm* |
 
 ## Run tests for this plugin
 

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -75,13 +75,10 @@ module Fastlane
       def self.check_platform(params)
         platform = params[:platform]
         if platform && !File.directory?("./platforms/#{platform}")
-          if params[:package_manager] == "yarn"
-            sh "yarn cordova platform add #{platform} --nofetch"
-          elsif params[:cordova_no_fetch]
-            sh "npx --no-install cordova platform add #{platform} --nofetch"
-          else
-            sh "npx --no-install cordova platform add #{platform}"
-          end
+          prefix = params[:node_package_manager] == "yarn" ? "yarn" : "npm --no-install"
+          suffix = params[:cordova_no_fetch] ? " --nofetch" : ""
+
+          sh prefix + " cordova platform add #{platform}" + suffix
         end
       end
 
@@ -94,6 +91,7 @@ module Fastlane
         args = [params[:release] ? '--release' : '--debug']
         args << '--device' if params[:device]
         args << '--browserify' if params[:browserify]
+        prefix = params[:node_package_manager] == "yarn" ? "yarn" : "npm --no-install"
 
         if !params[:cordova_build_config_file].to_s.empty?
           args << "--buildConfig=#{Shellwords.escape(params[:cordova_build_config_file])}"
@@ -103,11 +101,7 @@ module Fastlane
         ios_args = self.get_ios_args(params) if params[:platform].to_s == 'ios'
 
         if params[:cordova_prepare]
-          if params[:package_manager] == "yarn"
-            sh "yarn cordova prepare #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
-          else
-            sh "1qnpx --no-install cordova prepare #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
-          end
+          sh prefix + " cordova prepare #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
         end
 
         if params[:platform].to_s == 'ios' && !params[:build_number].to_s.empty?
@@ -121,11 +115,7 @@ module Fastlane
           )
         end
 
-        if params[:package_manager] == "yarn"
-          sh "yarn cordova compile #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
-        else
-          sh "npx --no-install cordova compile #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
-        end
+        sh prefix + " cordova compile #{params[:platform]} #{args.join(' ')} #{ios_args} -- #{android_args}"
       end
 
       def self.set_build_paths(params)

--- a/lib/fastlane/plugin/cordova/version.rb
+++ b/lib/fastlane/plugin/cordova/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Cordova
-    VERSION = "3.1.1"
+    VERSION = "3.2.1"
   end
 end

--- a/lib/fastlane/plugin/cordova/version.rb
+++ b/lib/fastlane/plugin/cordova/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Cordova
-    VERSION = "3.2.1"
+    VERSION = "3.2.0"
   end
 end


### PR DESCRIPTION
This makes it so you can add a parameter in your Fastfile that will make this plugin work with yarn. I think that it may only be required for yarn 2+ as yarn 1 still packages everything in to node_modules folder whereas this may not be the case in yarn 2.

Hint: I have never done any Ruby development before so 🤞 I haven't made any stupid Ruby specific mistakes that I am not aware of