### PR TITLE
Add 'rm before add' option to remove the platform before adding it again

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Which will produce:
 | **browserify**           | Specifies whether to browserify build or not            | CORDOVA_BROWSERIFY                |  *false*  |
 | **cordova_prepare**      | Specifies whether to run `cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |
 | **cordova_no_fetch**      | Specifies whether to run `cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
+| **cordova_rm_before_add**      | Specifies whether to run `cordova platform rm` before re-adding the platform  | CORDOVA_RM_BEFORE_ADD         |  *false*   |
 | **cordova_build_config_file**      | Call `cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path  | CORDOVA_BUILD_CONFIG_FILE               |     |
 
 ## Run tests for this plugin

--- a/lib/fastlane/plugin/cordova/actions/cordova_action.rb
+++ b/lib/fastlane/plugin/cordova/actions/cordova_action.rb
@@ -14,6 +14,7 @@ module Fastlane
         build_number: 'versionCode',
         min_sdk_version: 'gradleArg=-PcdvMinSdkVersion',
         cordova_no_fetch: 'cordovaNoFetch',
+        cordova_rm_before_add: 'cordovaRmBeforeAdd',
         package_type: 'packageType'
       }
 
@@ -72,11 +73,18 @@ module Fastlane
 
       def self.check_platform(params)
         platform = params[:platform]
-        if platform && !File.directory?("./platforms/#{platform}")
-          if params[:cordova_no_fetch]
-            sh "npx --no-install cordova platform add #{platform} --nofetch"
-          else
-            sh "npx --no-install cordova platform add #{platform}"
+        if platform
+          if params[:cordova_rm_before_add]
+            sh "npx --no-install cordova platform rm #{platform}"
+            FileUtils.rm_rf("./platforms/#{platform}")
+          end
+
+          if !File.directory?("./platforms/#{platform}")
+            if params[:cordova_no_fetch]
+              sh "npx --no-install cordova platform add #{platform} --nofetch"
+            else
+              sh "npx --no-install cordova platform add #{platform}"
+            end
           end
         end
       end
@@ -273,6 +281,13 @@ module Fastlane
             key: :cordova_no_fetch,
             env_name: "CORDOVA_NO_FETCH",
             description: "Call `npx cordova platform add` with `--nofetch` parameter",
+            default_value: false,
+            is_string: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :cordova_rm_before_add,
+            env_name: "CORDOVA_RM_BEFORE_ADD",
+            description: "Call `npx cordova platform rm` before adding the platform again",
             default_value: false,
             is_string: false
           ),


### PR DESCRIPTION
In order to perform a complete clean build (without calling clean), it makes sense to remove a platform (with all traces of a previous build) before adding it again. Previously this was not possible with this plugin.