### PR TITLE
Update the RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,11 @@ Metrics/BlockLength:
   Enabled: false
 
 # certificate_1 is an okay variable name
-Style/VariableNumber:
+Naming/VariableNumber:
   Enabled: false
 
 # This is used a lot across the fastlane code base for config files
-Style/MethodMissing:
+Style/MissingRespondToMissing:
   Enabled: false
 
 # 
@@ -38,24 +38,20 @@ Style/NumericLiteralPrefix:
 Style/TernaryParentheses:
   Enabled: false
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Style/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Style/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # We allow !! as it's an easy way to convert ot boolean
@@ -63,7 +59,7 @@ Style/DoubleNegation:
   Enabled: false
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.
@@ -157,7 +153,7 @@ Lint/ParenthesesAsGroupedExpression:
 
 # This would reject is_ in front of methods
 # We use `is_supported?` everywhere already
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # We allow the $
@@ -165,7 +161,7 @@ Style/PerlBackrefs:
   Enabled: false
 
 # Disable '+ should be surrounded with a single space' for xcodebuild_spec.rb
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Exclude:
     - '**/spec/actions_specs/xcodebuild_spec.rb'
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ platform :android do
       platform: 'android',
       keystore_path: './prod.keystore',
       keystore_alias: 'prod',
-      keystore_password: 'password'
+      keystore_password: 'password',
       build_flag: ['-UseModernBuildSystem=0']
     )
     supply(apk: ENV('CORDOVA_ANDROID_RELEASE_BUILD_PATH'))


### PR DESCRIPTION
Updated the RuboCop configuration file so that Travis CI builds no longer fail.

https://docs.rubocop.org/rubocop/1.19/cops_style.html#stylemissingrespondtomissing

The changes were based on the error output from this failed run on Travis CI:
https://app.travis-ci.com/github/bamlab/fastlane-plugin-cordova/builds/230500476

And errors I got from running `rake` locally:
```text
The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/BracesAroundHashParameters` cop has been removed. Please use  and/or  instead.
(obsolete configuration found in .rubocop.yml, please update it)
```